### PR TITLE
feat: Implement hierarchical health dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,22 @@ The base URL for the API is `http://localhost:5000/api`.
 -   `setup_dashboard.sh`: Initializes a set of common categories and items.
 -   `update_status_examples.sh`: Updates the statuses of some of the pre-initialized items to demonstrate different states.
 Make sure these scripts are executable (`chmod +x *.sh`).
+
+## Running Tests
+
+This project includes unit tests for the API and simulation tests for the example shell scripts.
+
+1.  **Navigate to the project root directory.**
+2.  **Run the tests using the `unittest` module:**
+    ```bash
+    python -m unittest discover tests
+    ```
+    Or, to run a specific test file:
+    ```bash
+    python -m unittest tests.test_app
+    python -m unittest tests.test_scripts
+    ```
+
+The tests are located in the `tests/` directory:
+-   `tests/test_app.py`: Contains unit tests for the Flask API endpoints.
+-   `tests/test_scripts.py`: Contains tests that simulate the execution of `setup_dashboard.sh` and `update_status_examples.sh` to verify their intended effect on the application state.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,154 @@
-# status-board
-generic status board
+# System Health Dashboard (Hierarchical)
+
+This is a web application to display the health status of various systems, organized into categories and items.
+It provides a dashboard view in a browser, showing one row per item with its category, status icons,
+status messages, last update times, and links for more details.
+
+States are managed via a REST API, allowing for dynamic creation and deletion of categories and items,
+as well as updates to item statuses.
+
+## Features
+
+-   Hierarchical health status display: items grouped under categories.
+-   Real-time (polling) health status display.
+-   Visual status indicators (icons) for each item.
+-   Timestamp for the last update of each item's status.
+-   Optional detailed messages and investigation links for each item.
+-   REST API for:
+    -   Querying all health data.
+    -   Creating and deleting categories.
+    -   Creating, deleting, and updating items within categories.
+
+## Project Structure
+
+```
+.
+├── app.py                       # Flask application (backend API and serving frontend)
+├── templates/
+│   └── index.html               # Main HTML page for the dashboard
+├── static/
+│   ├── script.js                # Frontend JavaScript for API interaction and DOM manipulation
+│   └── style.css                # CSS for styling the dashboard
+├── setup_dashboard.sh           # Example script to initialize the dashboard structure
+├── update_status_examples.sh    # Example script to update statuses of some items
+└── README.md                    # This file
+```
+
+## Setup and Running
+
+1.  **Prerequisites:**
+    *   Python 3.x
+    *   Flask (`pip install Flask`)
+    *   `curl` (for running the example scripts)
+
+2.  **Make Scripts Executable (Optional but Recommended):**
+    ```bash
+    chmod +x setup_dashboard.sh
+    chmod +x update_status_examples.sh
+    ```
+
+3.  **Run the Application:**
+    Navigate to the project directory and run:
+    ```bash
+    python app.py
+    ```
+    The application will be accessible at `http://localhost:5000`.
+
+4.  **Initialize Dashboard (Optional - using example script):**
+    In a separate terminal, while the app is running, execute:
+    ```bash
+    ./setup_dashboard.sh
+    ```
+    This will populate the dashboard with predefined categories and items in an "unknown" state.
+
+5.  **Update Statuses (Optional - using example script):**
+    After setup, you can update statuses:
+    ```bash
+    ./update_status_examples.sh
+    ```
+
+## API Endpoints
+
+The base URL for the API is `http://localhost:5000/api`.
+
+### Health Data
+
+#### Get All Health Data
+-   **URL:** `/health`
+-   **Method:** `GET`
+-   **Success Response (200 OK):**
+    ```json
+    {
+      "Builds": {
+        "Main Build": {"status": "passing", "last_updated": "...", "message": "...", "url": "..."}
+      },
+      "Host Up/Down": {
+        "mars": {"status": "down", "last_updated": "...", "message": "...", "url": "..."}
+      }
+    }
+    ```
+
+### Categories
+
+#### Create Category
+-   **URL:** `/categories`
+-   **Method:** `POST`
+-   **Headers:** `Content-Type: application/json`
+-   **Body:** `{"category_name": "New Category Name"}`
+-   **Success Response (201 Created):** `{"New Category Name": {}}`
+-   **Error Response (400 Bad Request):** If category exists or invalid payload.
+
+#### Delete Category
+-   **URL:** `/categories/<category_name>`
+    -   Example: `/categories/Builds` (Note: URL encode spaces or special characters, e.g., `Host%20Up%2FDown`)
+-   **Method:** `DELETE`
+-   **Success Response (200 OK):** `{"message": "Category '<category_name>' deleted successfully"}`
+-   **Error Response (404 Not Found):** If category does not exist.
+
+### Items (within Categories)
+
+#### Create Item in Category
+-   **URL:** `/categories/<category_name>/items`
+-   **Method:** `POST`
+-   **Headers:** `Content-Type: application/json`
+-   **Body:** `{"item_name": "New Item Name"}`
+    -   Item is created with "unknown" status and current timestamp.
+-   **Success Response (201 Created):** `{"New Item Name": {"status": "unknown", "last_updated": "...", "message": "", "url": ""}}`
+-   **Error Response (404 Not Found):** If category does not exist.
+-   **Error Response (400 Bad Request):** If item already exists or invalid payload.
+
+#### Update Item in Category
+-   **URL:** `/categories/<category_name>/items/<item_name>`
+    -   Example: `/categories/Builds/items/Main%20Build`
+-   **Method:** `PUT`
+-   **Headers:** `Content-Type: application/json`
+-   **Body (provide fields to update):**
+    ```json
+    {
+      "status": "passing",  // Valid: "running", "down", "passing", "failing", "unknown"
+      "message": "Optional detailed message",
+      "url": "Optional investigation URL"
+    }
+    ```
+-   **Success Response (200 OK):** The updated item object.
+-   **Error Response (404 Not Found):** If category or item does not exist.
+-   **Error Response (400 Bad Request):** If invalid status or payload.
+
+#### Delete Item from Category
+-   **URL:** `/categories/<category_name>/items/<item_name>`
+-   **Method:** `DELETE`
+-   **Success Response (200 OK):** `{"message": "Item '<item_name>' from category '<category_name>' deleted successfully"}`
+-   **Error Response (404 Not Found):** If category or item does not exist.
+
+## Frontend
+
+-   The frontend is served by Flask from `templates/index.html`.
+-   JavaScript (`static/script.js`) fetches data from `/api/health` every 30 seconds and updates the table.
+-   The table displays items grouped by category. The category name is shown for the first item in its group.
+-   CSS (`static/style.css`) provides styling.
+
+## Example Scripts
+
+-   `setup_dashboard.sh`: Initializes a set of common categories and items.
+-   `update_status_examples.sh`: Updates the statuses of some of the pre-initialized items to demonstrate different states.
+Make sure these scripts are executable (`chmod +x *.sh`).

--- a/setup_dashboard.sh
+++ b/setup_dashboard.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Script to set up the initial dashboard with categories and items.
+# All items will be in 'unknown' status by default upon creation via the API.
+
+API_BASE_URL="http://localhost:5000/api"
+
+echo "Creating categories..."
+curl -X POST -H "Content-Type: application/json" -d '{"category_name": "Builds"}' $API_BASE_URL/categories
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"category_name": "Tests"}' $API_BASE_URL/categories
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"category_name": "Host Up/Down"}' $API_BASE_URL/categories
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"category_name": "Operational Systems"}' $API_BASE_URL/categories
+echo ""
+
+echo "Adding items to 'Builds'..."
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "Main Build"}' "$API_BASE_URL/categories/Builds/items"
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "Release Build"}' "$API_BASE_URL/categories/Builds/items"
+echo ""
+
+echo "Adding items to 'Tests'..."
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "Login Test"}' "$API_BASE_URL/categories/Tests/items"
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "API Test"}' "$API_BASE_URL/categories/Tests/items"
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "Performance Test"}' "$API_BASE_URL/categories/Tests/items"
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "Security Scan"}' "$API_BASE_URL/categories/Tests/items"
+echo ""
+
+echo "Adding items to 'Host Up/Down'..."
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "mars"}' "$API_BASE_URL/categories/Host Up%2FDown/items" # URL encode space
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "saturn"}' "$API_BASE_URL/categories/Host Up%2FDown/items"
+echo ""
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "jupiter"}' "$API_BASE_URL/categories/Host Up%2FDown/items"
+echo ""
+
+echo "Adding item to 'Operational Systems'..."
+curl -X POST -H "Content-Type: application/json" -d '{"item_name": "Core OS Services"}' "$API_BASE_URL/categories/Operational Systems/items"
+echo ""
+
+echo "Setup complete. All items are initialized to 'unknown' status."
+echo "You might need to make this script executable: chmod +x setup_dashboard.sh"
+# To see the current state: curl http://localhost:5000/api/health

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,111 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const healthTableBody = document.getElementById('health-table').getElementsByTagName('tbody')[0];
+
+    /**
+     * Fetches health data from the API and triggers table update.
+     */
+    function fetchHealthData() {
+        fetch('/api/health')
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+                return response.json();
+            })
+            .then(data => {
+                updateTable(data);
+            })
+            .catch(error => {
+                console.error('Error fetching health data:', error);
+                healthTableBody.innerHTML = '<tr><td colspan="6" class="no-data">Error loading data. Check console.</td></tr>';
+            });
+    }
+
+    /**
+     * Updates the HTML table with the provided health data.
+     * @param {object} data - The health status data from the API.
+     *                         Example: {"CategoryName": {"ItemName": {"status": "...", ...}}}
+     */
+    function updateTable(data) {
+        healthTableBody.innerHTML = ''; // Clear existing rows
+
+        if (Object.keys(data).length === 0) {
+            healthTableBody.innerHTML = '<tr><td colspan="6" class="no-data">No health data available.</td></tr>';
+            return;
+        }
+
+        let isFirstItemInCategory = true;
+
+        for (const categoryName in data) {
+            if (data.hasOwnProperty(categoryName)) {
+                const items = data[categoryName];
+                isFirstItemInCategory = true; // Reset for each new category
+
+                if (Object.keys(items).length === 0) { // Display category even if it has no items yet
+                    const row = healthTableBody.insertRow();
+                    const categoryCell = row.insertCell();
+                    categoryCell.textContent = categoryName;
+                    categoryCell.className = 'category-cell';
+                    row.insertCell().colSpan = 5; // Empty cells for the rest of the row
+                } else {
+                    for (const itemName in items) {
+                        if (items.hasOwnProperty(itemName)) {
+                            const item = items[itemName];
+                            const row = healthTableBody.insertRow();
+
+                            // Category Cell
+                            const categoryCell = row.insertCell();
+                            if (isFirstItemInCategory) {
+                                categoryCell.textContent = categoryName;
+                                categoryCell.className = 'category-cell';
+                                isFirstItemInCategory = false;
+                            } else {
+                                categoryCell.textContent = ''; // Or '〃' or some ditto mark
+                            }
+
+                            // Item Name Cell
+                            const itemCell = row.insertCell();
+                            itemCell.textContent = itemName;
+
+                            // Status Cell (Icon + Text)
+                            const statusCell = row.insertCell();
+                            const statusIcon = document.createElement('span');
+                            const currentStatus = item.status ? item.status.toLowerCase() : 'unknown';
+                            statusIcon.className = `status-icon status-${currentStatus}`;
+                            statusCell.appendChild(statusIcon);
+                            const statusText = item.status ? item.status.charAt(0).toUpperCase() + item.status.slice(1) : 'Unknown';
+                            statusCell.appendChild(document.createTextNode(statusText));
+
+                            // Last Updated Cell
+                            const lastUpdatedCell = row.insertCell();
+                            lastUpdatedCell.textContent = item.last_updated ? new Date(item.last_updated).toLocaleString() : 'N/A';
+
+                            // Message Cell
+                            const messageCell = row.insertCell();
+                            messageCell.textContent = item.message || 'N/A';
+
+                            // Link Cell
+                            const linkCell = row.insertCell();
+                            if (item.url) {
+                                const link = document.createElement('a');
+                                link.href = item.url;
+                                link.textContent = 'Investigate';
+                                link.target = '_blank';
+                                link.rel = 'noopener noreferrer';
+                                linkCell.appendChild(link);
+                            } else {
+                                linkCell.textContent = 'N/A';
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Initial fetch of health data when the page loads
+    fetchHealthData();
+
+    // Set up polling to refresh health data every 30 seconds
+    setInterval(fetchHealthData, 30000); // 30000 milliseconds = 30 seconds
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,75 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    background-color: #f9f9f9;
+    color: #333;
+}
+
+h1 {
+    text-align: center;
+    color: #444;
+    margin-bottom: 30px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+    box-shadow: 0 2px 15px rgba(0, 0, 0, 0.1);
+    background-color: #fff;
+}
+
+th, td {
+    padding: 12px 15px;
+    text-align: left;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+th {
+    background-color: #007bff;
+    color: white;
+    font-weight: bold;
+}
+
+tr:nth-child(even) {
+    background-color: #f2f2f2;
+}
+
+tr:hover {
+    background-color: #e9ecef;
+}
+
+.status-icon {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 10px;
+    vertical-align: middle;
+    border: 1px solid rgba(0,0,0,0.1);
+}
+
+.status-running, .status-passing { background-color: #28a745; } /* Green */
+.status-down, .status-failing { background-color: #dc3545; } /* Red */
+.status-unknown { background-color: #ffc107; } /* Yellow */
+
+a {
+    color: #007bff;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.category-cell {
+    font-weight: bold;
+    color: #0056b3;
+}
+
+.no-data {
+    text-align: center;
+    padding: 20px;
+    font-style: italic;
+    color: #777;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>System Health Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>System Health Dashboard</h1>
+    <table id="health-table">
+        <thead>
+            <tr>
+                <th>Category</th>
+                <th>Item</th>
+                <th>Status</th>
+                <th>Last Updated</th>
+                <th>Message</th>
+                <th>Link</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Data will be populated by JavaScript -->
+        </tbody>
+    </table>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the `tests` directory as a package.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,184 @@
+import unittest
+import json
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Adjust path to import app from the parent directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import app as main_app # Renamed to avoid conflict with 'app' instance
+
+class TestAppAPI(unittest.TestCase):
+
+    def setUp(self):
+        """Set up for each test."""
+        main_app.app.testing = True
+        self.client = main_app.app.test_client()
+        # Reset health_data before each test
+        main_app.health_data.clear()
+        # Mock datetime
+        self.mock_datetime = MagicMock()
+        self.mock_datetime.utcnow.return_value.isoformat.return_value = "2023-01-01T12:00:00" # No 'Z' for direct isoformat
+        self.patcher = patch('app.datetime', self.mock_datetime) # Patch 'app.datetime'
+        self.patcher.start()
+
+    def tearDown(self):
+        """Clean up after each test."""
+        self.patcher.stop()
+
+    def _get_expected_timestamp(self):
+        return self.mock_datetime.utcnow.return_value.isoformat.return_value + 'Z'
+
+
+    # Category Tests
+    def test_create_category(self):
+        response = self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        self.assertEqual(response.status_code, 201)
+        self.assertIn('Cat1', response.json)
+        self.assertEqual(main_app.health_data['Cat1'], {})
+
+    def test_create_category_duplicate(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        response = self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', response.json)
+
+    def test_create_category_missing_name(self):
+        response = self.client.post('/api/categories', json={})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', response.json)
+
+    def test_delete_category(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        response = self.client.delete('/api/categories/Cat1')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Cat1', main_app.health_data)
+
+    def test_delete_category_not_found(self):
+        response = self.client.delete('/api/categories/NonExistentCat')
+        self.assertEqual(response.status_code, 404)
+
+    # Item Tests
+    def test_create_item(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        response = self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+        self.assertEqual(response.status_code, 201)
+        expected_item_data = {
+            "status": "unknown",
+            "last_updated": self._get_expected_timestamp(),
+            "message": "",
+            "url": ""
+        }
+        self.assertEqual(response.json['Item1'], expected_item_data)
+        self.assertEqual(main_app.health_data['Cat1']['Item1'], expected_item_data)
+
+    def test_create_item_category_not_found(self):
+        response = self.client.post('/api/categories/NonExistentCat/items', json={'item_name': 'Item1'})
+        self.assertEqual(response.status_code, 404)
+
+    def test_create_item_duplicate(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+        response = self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_item_missing_name(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        response = self.client.post('/api/categories/Cat1/items', json={})
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_item(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+
+        update_payload = {"status": "passing", "message": "All good", "url": "http://example.com"}
+        response = self.client.put('/api/categories/Cat1/items/Item1', json=update_payload)
+        self.assertEqual(response.status_code, 200)
+
+        expected_item_data = {
+            "status": "passing",
+            "last_updated": self._get_expected_timestamp(),
+            "message": "All good",
+            "url": "http://example.com"
+        }
+        self.assertEqual(response.json['Item1'], expected_item_data)
+        self.assertEqual(main_app.health_data['Cat1']['Item1'], expected_item_data)
+
+    def test_update_item_partial(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'}) # Initial state: unknown, no msg/url
+
+        update_payload = {"status": "failing"}
+        response = self.client.put('/api/categories/Cat1/items/Item1', json=update_payload)
+        self.assertEqual(response.status_code, 200)
+
+        expected_item_data = {
+            "status": "failing",
+            "last_updated": self._get_expected_timestamp(),
+            "message": "", # Unchanged
+            "url": ""      # Unchanged
+        }
+        self.assertEqual(response.json['Item1'], expected_item_data)
+        self.assertEqual(main_app.health_data['Cat1']['Item1'], expected_item_data)
+
+    def test_update_item_invalid_status(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+        response = self.client.put('/api/categories/Cat1/items/Item1', json={'status': 'invalid_state'})
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_item_category_not_found(self):
+        response = self.client.put('/api/categories/NonExistentCat/items/Item1', json={'status': 'passing'})
+        self.assertEqual(response.status_code, 404)
+
+    def test_update_item_item_not_found(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        response = self.client.put('/api/categories/Cat1/items/NonExistentItem', json={'status': 'passing'})
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_item(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+        response = self.client.delete('/api/categories/Cat1/items/Item1')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Item1', main_app.health_data['Cat1'])
+
+    def test_delete_item_category_not_found(self):
+        response = self.client.delete('/api/categories/NonExistentCat/items/Item1')
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_item_item_not_found(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        response = self.client.delete('/api/categories/Cat1/items/NonExistentItem')
+        self.assertEqual(response.status_code, 404)
+
+    # GET Health Data Test
+    def test_get_health_data(self):
+        self.client.post('/api/categories', json={'category_name': 'Cat1'})
+        self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+        self.client.put('/api/categories/Cat1/items/Item1', json={"status": "passing", "message": "OK"})
+
+        response = self.client.get('/api/health')
+        self.assertEqual(response.status_code, 200)
+
+        expected_data = {
+            "Cat1": {
+                "Item1": {
+                    "status": "passing",
+                    "last_updated": self._get_expected_timestamp(),
+                    "message": "OK",
+                    "url": ""
+                }
+            }
+        }
+        self.assertEqual(response.json, expected_data)
+        self.assertEqual(main_app.health_data, expected_data)
+
+    def test_get_empty_health_data(self):
+        response = self.client.get('/api/health')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {})
+        self.assertEqual(main_app.health_data, {})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,138 @@
+import unittest
+import json
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Adjust path to import app from the parent directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import app as main_app # Renamed to avoid conflict with 'app' instance
+
+class TestShellScriptsSimulated(unittest.TestCase):
+
+    def setUp(self):
+        """Set up for each test."""
+        main_app.app.testing = True
+        self.client = main_app.app.test_client()
+        main_app.health_data.clear() # Reset health_data
+
+        # Mock datetime for consistent timestamps
+        self.mock_datetime = MagicMock()
+        # Ensure isoformat() is called on the MagicMock object that utcnow() returns
+        self.mock_datetime.utcnow.return_value.isoformat.return_value = "2023-01-01T12:00:00"
+        self.patcher = patch('app.datetime', self.mock_datetime)
+        self.patcher.start()
+
+    def tearDown(self):
+        """Clean up after each test."""
+        self.patcher.stop()
+
+    def _get_expected_timestamp(self):
+        return self.mock_datetime.utcnow.return_value.isoformat.return_value + 'Z'
+
+    def simulate_setup_dashboard_sh(self):
+        """Simulates the actions of setup_dashboard.sh using the test client."""
+        # Create categories
+        categories = ["Builds", "Tests", "Host Up/Down", "Operational Systems"]
+        for cat in categories:
+            self.client.post('/api/categories', json={'category_name': cat})
+
+        # Add items
+        self.client.post('/api/categories/Builds/items', json={'item_name': 'Main Build'})
+        self.client.post('/api/categories/Builds/items', json={'item_name': 'Release Build'})
+
+        test_items = ["Login Test", "API Test", "Performance Test", "Security Scan"]
+        for item in test_items:
+            self.client.post('/api/categories/Tests/items', json={'item_name': item})
+
+        host_items = ["mars", "saturn", "jupiter"]
+        for item in host_items:
+            self.client.post('/api/categories/Host Up%2FDown/items', json={'item_name': item})
+
+        self.client.post('/api/categories/Operational Systems/items', json={'item_name': 'Core OS Services'})
+
+    def simulate_update_status_examples_sh(self):
+        """Simulates the actions of update_status_examples.sh using the test client."""
+        ts = self._get_expected_timestamp()
+
+        # Update "Main Build"
+        self.client.put('/api/categories/Builds/items/Main%20Build',
+                        json={"status": "passing", "message": "Build successful on commit abc1234", "url": "http://jenkins.example.com/builds/main/101"})
+
+        # Update "mars"
+        self.client.put('/api/categories/Host%20Up%2FDown/items/mars',
+                        json={"status": "down", "message": "Host mars is unresponsive, ping failed.", "url": "http://monitoring.example.com/hosts/mars"})
+        # Update "jupiter"
+        self.client.put('/api/categories/Host%20Up%2FDown/items/jupiter',
+                        json={"status": "running", "message": "All systems normal.", "url": "http://monitoring.example.com/hosts/jupiter"})
+
+        # Update "Login Test"
+        self.client.put('/api/categories/Tests/items/Login%20Test',
+                        json={"status": "failing", "message": "Login test failed: credentials expired.", "url": "http://tests.example.com/results/login/latest"})
+        # Update "API Test"
+        self.client.put('/api/categories/Tests/items/API%20Test',
+                        json={"status": "passing", "message": "All API endpoints responding correctly.", "url": "http://tests.example.com/results/api/latest"})
+
+        # Update "Core OS Services"
+        self.client.put('/api/categories/Operational%20Systems/items/Core%20OS%20Services',
+                        json={"status": "running", "message": "Operational system services are stable.", "url": "http://status.example.com/os"})
+
+
+    def test_setup_dashboard_script_simulation(self):
+        """Test the state of health_data after simulating setup_dashboard.sh."""
+        self.simulate_setup_dashboard_sh()
+
+        health = main_app.health_data
+        self.assertIn("Builds", health)
+        self.assertIn("Main Build", health["Builds"])
+        self.assertEqual(health["Builds"]["Main Build"]["status"], "unknown")
+        self.assertEqual(health["Builds"]["Release Build"]["status"], "unknown")
+
+        self.assertIn("Tests", health)
+        self.assertEqual(len(health["Tests"]), 4)
+        self.assertEqual(health["Tests"]["Login Test"]["status"], "unknown")
+
+        self.assertIn("Host Up/Down", health)
+        self.assertEqual(len(health["Host Up/Down"]), 3)
+        self.assertEqual(health["Host Up/Down"]["mars"]["status"], "unknown")
+
+        self.assertIn("Operational Systems", health)
+        self.assertEqual(health["Operational Systems"]["Core OS Services"]["status"], "unknown")
+        self.assertEqual(health["Operational Systems"]["Core OS Services"]["last_updated"], self._get_expected_timestamp())
+
+
+    def test_update_status_examples_script_simulation(self):
+        """Test the state of health_data after simulating both scripts."""
+        self.simulate_setup_dashboard_sh() # Start with the base setup
+        self.simulate_update_status_examples_sh() # Apply updates
+
+        health = main_app.health_data
+        ts = self._get_expected_timestamp()
+
+        # Check updated items
+        self.assertEqual(health["Builds"]["Main Build"]["status"], "passing")
+        self.assertEqual(health["Builds"]["Main Build"]["message"], "Build successful on commit abc1234")
+        self.assertEqual(health["Builds"]["Main Build"]["last_updated"], ts)
+
+        self.assertEqual(health["Host Up/Down"]["mars"]["status"], "down")
+        self.assertEqual(health["Host Up/Down"]["jupiter"]["status"], "running")
+
+        self.assertEqual(health["Tests"]["Login Test"]["status"], "failing")
+        self.assertEqual(health["Tests"]["API Test"]["status"], "passing")
+
+        self.assertEqual(health["Operational Systems"]["Core OS Services"]["status"], "running")
+
+        # Check an item that wasn't updated by update_status_examples.sh (e.g., Release Build)
+        # Its timestamp should be from the setup simulation step, not the update simulation
+        # This requires more precise timestamp mocking or careful checking if all updated items get new timestamps
+        # For now, we assume all PUT operations in update script update the timestamp.
+        self.assertEqual(health["Builds"]["Release Build"]["status"], "unknown")
+        # To properly test this, we'd need to mock timestamps differently for setup vs update,
+        # or verify that its timestamp is NOT the one from the update phase.
+        # The current _get_expected_timestamp() returns the same for the whole test method.
+        # This is a limitation of the current simple timestamp mocking.
+        # A more advanced mock could return different values on subsequent calls.
+        # For now, we'll focus on the changed items.
+
+if __name__ == '__main__':
+    unittest.main()

--- a/update_status_examples.sh
+++ b/update_status_examples.sh
@@ -10,20 +10,22 @@ echo "Updating statuses..."
 echo "Updating Main Build..."
 curl -X PUT -H "Content-Type: application/json" \
   -d '{"status": "passing", "message": "Build successful on commit abc1234", "url": "http://jenkins.example.com/builds/main/101"}' \
-  "$API_BASE_URL/categories/Builds/items/Main Build"
+  "$API_BASE_URL/categories/Builds/items/Main%20Build"
 echo ""
 
 # Update "mars" to "down", "jupiter" to "running"
+# These item names ("mars", "jupiter") do not have spaces, so no URL encoding needed for them.
+# The category "Host Up/Down" is correctly encoded in its path segment.
 echo "Updating Host: mars..."
 curl -X PUT -H "Content-Type: application/json" \
   -d '{"status": "down", "message": "Host mars is unresponsive, ping failed.", "url": "http://monitoring.example.com/hosts/mars"}' \
-  "$API_BASE_URL/categories/Host Up%2FDown/items/mars"
+  "$API_BASE_URL/categories/Host%20Up%2FDown/items/mars"
 echo ""
 
 echo "Updating Host: jupiter..."
 curl -X PUT -H "Content-Type: application/json" \
   -d '{"status": "running", "message": "All systems normal.", "url": "http://monitoring.example.com/hosts/jupiter"}' \
-  "$API_BASE_URL/categories/Host Up%2FDown/items/jupiter"
+  "$API_BASE_URL/categories/Host%20Up%2FDown/items/jupiter"
 echo ""
 
 
@@ -31,13 +33,13 @@ echo ""
 echo "Updating Test: Login Test..."
 curl -X PUT -H "Content-Type: application/json" \
   -d '{"status": "failing", "message": "Login test failed: credentials expired.", "url": "http://tests.example.com/results/login/latest"}' \
-  "$API_BASE_URL/categories/Tests/items/Login Test"
+  "$API_BASE_URL/categories/Tests/items/Login%20Test"
 echo ""
 
 echo "Updating Test: API Test..."
 curl -X PUT -H "Content-Type: application/json" \
   -d '{"status": "passing", "message": "All API endpoints responding correctly.", "url": "http://tests.example.com/results/api/latest"}' \
-  "$API_BASE_URL/categories/Tests/items/API Test"
+  "$API_BASE_URL/categories/Tests/items/API%20Test"
 echo ""
 
 
@@ -45,7 +47,7 @@ echo ""
 echo "Updating Operational System: Core OS Services..."
 curl -X PUT -H "Content-Type: application/json" \
   -d '{"status": "running", "message": "Operational system services are stable.", "url": "http://status.example.com/os"}' \
-  "$API_BASE_URL/categories/Operational Systems/items/Core OS Services"
+  "$API_BASE_URL/categories/Operational%20Systems/items/Core%20OS%20Services"
 echo ""
 
 

--- a/update_status_examples.sh
+++ b/update_status_examples.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Script to update the status of some items on the dashboard.
+
+API_BASE_URL="http://localhost:5000/api"
+
+echo "Updating statuses..."
+
+# Update "Main Build" to "passing"
+echo "Updating Main Build..."
+curl -X PUT -H "Content-Type: application/json" \
+  -d '{"status": "passing", "message": "Build successful on commit abc1234", "url": "http://jenkins.example.com/builds/main/101"}' \
+  "$API_BASE_URL/categories/Builds/items/Main Build"
+echo ""
+
+# Update "mars" to "down", "jupiter" to "running"
+echo "Updating Host: mars..."
+curl -X PUT -H "Content-Type: application/json" \
+  -d '{"status": "down", "message": "Host mars is unresponsive, ping failed.", "url": "http://monitoring.example.com/hosts/mars"}' \
+  "$API_BASE_URL/categories/Host Up%2FDown/items/mars"
+echo ""
+
+echo "Updating Host: jupiter..."
+curl -X PUT -H "Content-Type: application/json" \
+  -d '{"status": "running", "message": "All systems normal.", "url": "http://monitoring.example.com/hosts/jupiter"}' \
+  "$API_BASE_URL/categories/Host Up%2FDown/items/jupiter"
+echo ""
+
+
+# Update "Login Test" to "failing", "API Test" to "passing"
+echo "Updating Test: Login Test..."
+curl -X PUT -H "Content-Type: application/json" \
+  -d '{"status": "failing", "message": "Login test failed: credentials expired.", "url": "http://tests.example.com/results/login/latest"}' \
+  "$API_BASE_URL/categories/Tests/items/Login Test"
+echo ""
+
+echo "Updating Test: API Test..."
+curl -X PUT -H "Content-Type: application/json" \
+  -d '{"status": "passing", "message": "All API endpoints responding correctly.", "url": "http://tests.example.com/results/api/latest"}' \
+  "$API_BASE_URL/categories/Tests/items/API Test"
+echo ""
+
+
+# Update "Core OS Services" to "running"
+echo "Updating Operational System: Core OS Services..."
+curl -X PUT -H "Content-Type: application/json" \
+  -d '{"status": "running", "message": "Operational system services are stable.", "url": "http://status.example.com/os"}' \
+  "$API_BASE_URL/categories/Operational Systems/items/Core OS Services"
+echo ""
+
+
+echo "Status updates complete."
+echo "You might need to make this script executable: chmod +x update_status_examples.sh"
+# To see the current state: curl http://localhost:5000/api/health


### PR DESCRIPTION
This commit refactors the health dashboard to support a hierarchical structure with categories and items. Categories are containers for items, and only items have a health status, message, and URL.

Key changes:
- Data model updated to a nested dictionary: `health_data[category][item]`.
- Flask API redesigned with endpoints for CRUD operations on categories and items within categories:
    - GET /api/health
    - POST /api/categories
    - DELETE /api/categories/<cat_name>
    - POST /api/categories/<cat_name>/items
    - PUT /api/categories/<cat_name>/items/<item_name>
    - DELETE /api/categories/<cat_name>/items/<item_name>
- Frontend (HTML/CSS/JS) updated to display items grouped by category. The category name is shown once per group of items.
- Added example shell scripts (`setup_dashboard.sh`, `update_status_examples.sh`) using `curl` to initialize and update dashboard data via the API.
- Comprehensive README.md detailing the new structure, API, and setup.