### PR TITLE
refactor: Return 200 OK if creating an already existing item

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, jsonify, request, render_template
 import datetime
+import json
+
 
 app = Flask(__name__)
 
@@ -11,19 +13,23 @@ app = Flask(__name__)
 # }
 health_data = {}
 
+
 def get_default_item_status():
     """Returns the default status dictionary for a new item."""
     return {"status": "unknown", "last_updated": None, "message": "", "url": ""}
+
 
 @app.route('/')
 def index():
     """Serves the main HTML page."""
     return render_template('index.html')
 
+
 @app.route('/api/health', methods=['GET'])
 def get_health_data_api():
     """API endpoint to get all health data."""
     return jsonify(health_data)
+
 
 @app.route('/api/categories', methods=['POST'])
 def create_category_api():
@@ -39,6 +45,7 @@ def create_category_api():
     health_data[category_name] = {}
     return jsonify({category_name: health_data[category_name]}), 201
 
+
 @app.route('/api/categories/<category_name>', methods=['DELETE'])
 def delete_category_api(category_name):
     """API endpoint to delete a category."""
@@ -47,6 +54,7 @@ def delete_category_api(category_name):
 
     del health_data[category_name]
     return jsonify({"message": f"Category '{category_name}' deleted successfully"}), 200
+
 
 @app.route('/api/categories/<category_name>/items', methods=['POST'])
 def create_item_api(category_name):
@@ -60,11 +68,15 @@ def create_item_api(category_name):
 
     item_name = data['item_name']
     if item_name in health_data[category_name]:
-        return jsonify({"error": f"Item '{item_name}' already exists in category '{category_name}'"}), 400
+        existing_item_data = health_data[category_name][item_name]
+        response_data = {"note": "Item already existed."}
+        response_data.update(existing_item_data)
+        return jsonify(response_data), 200
 
     health_data[category_name][item_name] = get_default_item_status()
     health_data[category_name][item_name]['last_updated'] = datetime.datetime.utcnow().isoformat() + 'Z'
     return jsonify({item_name: health_data[category_name][item_name]}), 201
+
 
 @app.route('/api/categories/<category_name>/items/<item_name>', methods=['DELETE'])
 def delete_item_api(category_name, item_name):
@@ -79,6 +91,7 @@ def delete_item_api(category_name, item_name):
     # if not health_data[category_name]:
     #     del health_data[category_name]
     return jsonify({"message": f"Item '{item_name}' from category '{category_name}' deleted successfully"}), 200
+
 
 @app.route('/api/categories/<category_name>/items/<item_name>', methods=['PUT'])
 def update_item_api(category_name, item_name):
@@ -110,6 +123,36 @@ def update_item_api(category_name, item_name):
     item['last_updated'] = datetime.datetime.utcnow().isoformat() + 'Z'
 
     return jsonify({item_name: item})
+
+
+@app.route('/api/checkpoint', methods=['POST'])
+def checkpoint_data():
+    """Saves the current health_data to a file."""
+    try:
+        with open('health_data.json', 'w') as f:
+            json.dump(health_data, f, indent=4)
+        return jsonify({"message": "Data checkpointed successfully to health_data.json"}), 200
+    except IOError as e:
+        return jsonify({"error": f"Failed to write checkpoint file: {str(e)}"}), 500
+
+
+@app.route('/api/restore', methods=['POST'])
+def restore_data():
+    """Restores health_data from a file."""
+    global health_data  # noqa: F824
+    try:
+        with open('health_data.json', 'r') as f:
+            data_from_file = json.load(f)
+            health_data.clear()
+            health_data.update(data_from_file)
+        return jsonify({"message": "Data restored successfully from health_data.json"}), 200
+    except FileNotFoundError:
+        return jsonify({"error": "Checkpoint file 'health_data.json' not found"}), 404
+    except json.JSONDecodeError as e:
+        return jsonify({"error": f"Invalid JSON in checkpoint file: {str(e)}"}), 500
+    except IOError as e:  # Catch other potential I/O errors during read
+        return jsonify({"error": f"Failed to read checkpoint file: {str(e)}"}), 500
+
 
 if __name__ == '__main__':
     # Ensure Flask runs on 0.0.0.0 to be accessible externally if needed (e.g. in a container)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -81,9 +81,21 @@ class TestAppAPI(unittest.TestCase):
 
     def test_create_item_duplicate(self):
         self.client.post('/api/categories', json={'category_name': 'Cat1'})
-        self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+        # First creation
+        first_response = self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
+        self.assertEqual(first_response.status_code, 201)
+        created_item_data = first_response.json['Item1']
+
+        # Attempt to create duplicate
         response = self.client.post('/api/categories/Cat1/items', json={'item_name': 'Item1'})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json
+        self.assertEqual(response_json.get("note"), "Item already existed.")
+        # Check that the other fields match the originally created item
+        self.assertEqual(response_json.get("status"), created_item_data["status"])
+        self.assertEqual(response_json.get("last_updated"), created_item_data["last_updated"])
+        self.assertEqual(response_json.get("message"), created_item_data["message"])
+        self.assertEqual(response_json.get("url"), created_item_data["url"])
 
     def test_create_item_missing_name(self):
         self.client.post('/api/categories', json={'category_name': 'Cat1'})
@@ -198,6 +210,63 @@ class TestAppAPI(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json, {})
         self.assertEqual(main_app.health_data, {})
+
+    # Checkpoint and Restore Tests
+    def test_checkpoint_and_restore(self):
+        # 1. Setup initial data
+        self.client.post('/api/categories', json={'category_name': 'TestCat'})
+        self.client.post('/api/categories/TestCat/items', json={'item_name': 'TestItem'})
+        update_payload = {"status": "passing", "message": "Checkpoint test", "url": "http://checkpoint.example.com"}
+        self.client.put('/api/categories/TestCat/items/TestItem', json=update_payload)
+
+        initial_data = main_app.health_data.copy()
+
+        # 2. Test /checkpoint
+        response_checkpoint = self.client.post('/api/checkpoint')
+        self.assertEqual(response_checkpoint.status_code, 200)
+        self.assertIn("Data checkpointed successfully", response_checkpoint.json['message'])
+
+        # Verify file content
+        self.assertTrue(os.path.exists('health_data.json'))
+        with open('health_data.json', 'r') as f:
+            data_from_file = json.load(f)
+        self.assertEqual(data_from_file, initial_data)
+
+        # 3. Modify in-memory data to ensure restore actually works
+        main_app.health_data.clear()
+        main_app.health_data['AnotherCat'] = {} # Make it different from checkpointed data
+
+        # 4. Test /restore
+        response_restore = self.client.post('/api/restore')
+        self.assertEqual(response_restore.status_code, 200)
+        self.assertIn("Data restored successfully", response_restore.json['message'])
+        self.assertEqual(main_app.health_data, initial_data) # Should be back to original
+
+        # 5. Clean up
+        if os.path.exists('health_data.json'):
+            os.remove('health_data.json')
+
+    def test_restore_file_not_found(self):
+        # Ensure file does not exist
+        if os.path.exists('health_data.json'):
+            os.remove('health_data.json')
+
+        response = self.client.post('/api/restore')
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("not found", response.json['error'])
+
+    def test_restore_invalid_json(self):
+        # Create an invalid JSON file
+        with open('health_data.json', 'w') as f:
+            f.write("this is not valid json")
+
+        response = self.client.post('/api/restore')
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("Invalid JSON", response.json['error'])
+
+        # Clean up
+        if os.path.exists('health_data.json'):
+            os.remove('health_data.json')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Modifies the behavior of the `POST /api/categories/<cat>/items` endpoint. If an item with the given name already exists in the category, the API now returns a `200 OK` status code instead of `400 Bad Request`.

The response body includes the existing item's data along with a `note: "Item already existed."` field to inform the client.

This change makes the item creation endpoint more idempotent and user-friendly when the intent is to "ensure an item exists".

Test cases for duplicate item creation have been updated to reflect this new behavior. Amends previous commits on this branch.