### PR TITLE
Add verbose option to health_board.py

### DIFF
--- a/health_board.py
+++ b/health_board.py
@@ -6,24 +6,28 @@ import json
 BASE_URL = "http://127.0.0.1:5000/api"
 
 @click.group()
-def board():
+@click.option('--verbose', '-v', is_flag=True, help="Enable verbose output.")
+def board(verbose):
     """A CLI client to interact with the Health Dashboard API."""
-    pass
+    # Store verbose flag in context for other commands to use
+    ctx = click.get_current_context()
+    ctx.obj = {'verbose': verbose}
 
 # --- API Interaction Functions ---
 
-def handle_response(response):
+def handle_response(response, verbose=False):
     """Helper function to handle API responses."""
     if response.ok:
-        try:
-            click.echo(click.style("Success:", fg="green"))
-            click.echo(json.dumps(response.json(), indent=2))
-        except json.JSONDecodeError:
-            # If no JSON body, just print a success message if that's the case
-            if response.text:
-                click.echo(response.text)
-            else:
-                click.echo(f"Status Code: {response.status_code} (No content)")
+        if verbose:
+            try:
+                click.echo(click.style("Success:", fg="green"))
+                click.echo(json.dumps(response.json(), indent=2))
+            except json.JSONDecodeError:
+                # If no JSON body, just print a success message if that's the case
+                if response.text:
+                    click.echo(response.text)
+                else:
+                    click.echo(f"Status Code: {response.status_code} (No content)")
     else:
         click.echo(click.style(f"Error: {response.status_code}", fg="red"))
         try:
@@ -80,20 +84,26 @@ def create():
 
 @create.command(name="category")
 @click.argument('category_name')
-def create_category(category_name):
+@click.pass_context
+def create_category(ctx, category_name):
     """Create a new category."""
-    click.echo(f"Creating category: {category_name}...")
+    verbose = ctx.obj['verbose']
+    if verbose:
+        click.echo(f"Creating category: {category_name}...")
     response = api_create_category(category_name)
-    handle_response(response)
+    handle_response(response, verbose)
 
 @create.command(name="item")
 @click.argument('category_name')
 @click.argument('item_name')
-def create_item(category_name, item_name):
+@click.pass_context
+def create_item(ctx, category_name, item_name):
     """Create a new item within a category."""
-    click.echo(f"Creating item '{item_name}' in category '{category_name}'...")
+    verbose = ctx.obj['verbose']
+    if verbose:
+        click.echo(f"Creating item '{item_name}' in category '{category_name}'...")
     response = api_create_item(category_name, item_name)
-    handle_response(response)
+    handle_response(response, verbose)
 
 @board.group()
 def remove():
@@ -102,21 +112,27 @@ def remove():
 
 @remove.command(name="category")
 @click.argument('category_name')
-def remove_category(category_name):
+@click.pass_context
+def remove_category(ctx, category_name):
     """Remove a category and all its items."""
-    click.echo(f"Removing category: {category_name}...")
+    verbose = ctx.obj['verbose']
+    if verbose:
+        click.echo(f"Removing category: {category_name}...")
     # It might be good to add a confirmation prompt here in a real CLI
     response = api_delete_category(category_name)
-    handle_response(response)
+    handle_response(response, verbose)
 
 @remove.command(name="item")
 @click.argument('category_name')
 @click.argument('item_name')
-def remove_item(category_name, item_name):
+@click.pass_context
+def remove_item(ctx, category_name, item_name):
     """Remove an item from a category."""
-    click.echo(f"Removing item '{item_name}' from category '{category_name}'...")
+    verbose = ctx.obj['verbose']
+    if verbose:
+        click.echo(f"Removing item '{item_name}' from category '{category_name}'...")
     response = api_delete_item(category_name, item_name)
-    handle_response(response)
+    handle_response(response, verbose)
 
 # Placeholder for update command
 @board.command()
@@ -125,42 +141,54 @@ def remove_item(category_name, item_name):
 @click.option('--status', help="The new status for the item (e.g., running, down, passing, failing, unknown, up).")
 @click.option('--message', help="A descriptive message for the item's status.")
 @click.option('--url', help="A URL related to the item for more details.")
-def update(category_name, item_name, status, message, url):
+@click.pass_context
+def update(ctx, category_name, item_name, status, message, url):
     """Update an item's status, message, or URL."""
+    verbose = ctx.obj['verbose']
     if not status and not message and not url:
         click.echo(click.style("Error: At least one of --status, --message, or --url must be provided.", fg="red"))
         # You might want to show help here or exit with an error code
         # For now, just printing and returning
         return
 
-    click.echo(f"Updating item '{item_name}' in category '{category_name}'...")
+    if verbose:
+        click.echo(f"Updating item '{item_name}' in category '{category_name}'...")
     response = api_update_item(category_name, item_name, status, message, url)
     if response: # api_update_item returns None if no parameters were given
-        handle_response(response)
+        handle_response(response, verbose)
 
 # Placeholder for save command
 @board.command()
-def save():
+@click.pass_context
+def save(ctx):
     """Save the current board data to a checkpoint file (health_data.json)."""
-    click.echo("Saving (checkpointing) board data...")
+    verbose = ctx.obj['verbose']
+    if verbose:
+        click.echo("Saving (checkpointing) board data...")
     response = api_checkpoint()
-    handle_response(response)
+    handle_response(response, verbose)
 
 # Placeholder for restore command
 @board.command()
-def restore():
+@click.pass_context
+def restore(ctx):
     """Restore the board data from the checkpoint file (health_data.json)."""
-    click.echo("Restoring board data from checkpoint...")
+    verbose = ctx.obj['verbose']
+    if verbose:
+        click.echo("Restoring board data from checkpoint...")
     response = api_restore()
-    handle_response(response)
+    handle_response(response, verbose)
 
 # Placeholder for show command
 @board.command()
-def show():
+@click.pass_context
+def show(ctx):
     """Show the current board data."""
-    click.echo("Fetching current board data...")
+    verbose = ctx.obj['verbose']
+    if verbose:
+        click.echo("Fetching current board data...")
     response = api_get_health()
-    handle_response(response) # This will print the JSON nicely
+    handle_response(response, verbose) # This will print the JSON nicely
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Added a `--verbose`/`-v` flag to the main `board` group.
- Modified command functions and `handle_response` to respect the verbose flag.
- Standard operation with no errors now produces no output.
- Verbose output includes informational messages and successful API responses.
- Error messages are always displayed regardless of the verbose flag.