### PR TITLE
feat: Add HealthBoardUpdater class

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,47 @@ The primary way to run the client after making it executable is `./health_board.
     ./health_board.py restore
     ```
 
+## Python API Client (`health_board_api.py`)
+
+A Python client, `health_board_api.py`, is provided for programmatic interaction with the Health Dashboard API.
+
+### `HealthBoard` Class
+
+The `HealthBoard` class is a general-purpose client for the API.
+
+**Initialization:**
+```python
+from health_board_api import HealthBoard
+
+client = HealthBoard(base_url="http://127.0.0.1:5000/api")
+```
+
+**Methods:**
+-   `get_health()`: Fetches the entire health board.
+-   `create_category(category_name)`
+-   `delete_category(category_name)`
+-   `create_item(category_name, item_name)`
+-   `delete_item(category_name, item_name)`
+-   `update_item(category_name, item_name, status, message, url)`
+-   `checkpoint()`: Saves the current state to a file.
+-   `restore()`: Restores the state from a file.
+
+### `HealthBoardUpdater` Class
+
+The `HealthBoardUpdater` class is a specialized client for updating a single, specific item. It inherits from `HealthBoard`.
+
+**Initialization:**
+```python
+from health_board_api import HealthBoardUpdater
+
+item_updater = HealthBoardUpdater(base_url="http://127.0.0.1:5000/api", category="services", item="database")
+```
+
+**Methods:**
+-   `update_item(status, message, url)`: Updates the specific item this client is configured for.
+
+All other methods from `HealthBoard` are also available.
+
 ## Bash CLI Client (`health_board.sh`)
 
 A Bash command-line client, `health_board.sh`, is also provided as an alternative for interacting with the Health Dashboard API using `curl`. It mirrors the core functionality of the Python client.

--- a/health_board_api.py
+++ b/health_board_api.py
@@ -136,3 +136,66 @@ class HealthBoard:
 
         response = self._request('PUT', endpoint, json=payload)
         return response.json()
+
+
+class HealthBoardUpdater(HealthBoard):
+    """
+    A specialized HealthBoard client for updating a single item.
+    """
+
+    def __init__(self, base_url: str, category: str, item: str):
+        """
+        Initializes the HealthBoardUpdater.
+
+        Args:
+            base_url: The base URL of the Health Board API.
+            category: The name of the category.
+            item: The name of the item.
+        """
+        super().__init__(base_url)
+        self.category = category
+        self.item = item
+
+    def update_item(self, status: Optional[str] = None, message: Optional[str] = None, url: Optional[str] = None, upsert: bool = True) -> Dict[str, Any]:
+        """
+        Updates the item's status, message, or URL.
+
+        Args:
+            status: The new status for the item.
+            message: The new message for the item.
+            url: The new URL for the item.
+            upsert: If True, the category and item will be created if they do not exist.
+
+        Returns:
+            The JSON response from the API.
+        """
+        return super().update_item(self.category, self.item, status, message, url, upsert)
+
+
+if __name__ == '__main__':
+    # Example usage:
+    # Make sure your Flask app is running before executing this script.
+
+    # Using HealthBoard to manage categories and items
+    client = HealthBoard(base_url="http://127.0.0.1:5000/api")
+    try:
+        print("Creating category 'services'...")
+        client.create_category("services")
+        print("Creating item 'database' in 'services'...")
+        client.create_item("services", "database")
+        print("Updating item 'database'...")
+        client.update_item("services", "database", status="up", message="Database is running normally.")
+        print("\nCurrent health status:")
+        print(client.get_health())
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred: {e}")
+
+    # Using HealthBoardUpdater for a specific item
+    item_updater = HealthBoardUpdater(base_url="http://127.0.0.1:5000/api", category="services", item="database")
+    try:
+        print("\nUpdating 'database' status to 'down' using HealthBoardUpdater...")
+        item_updater.update_item(status="down", message="Database is offline for maintenance.")
+        print("\nCurrent health status:")
+        print(item_updater.get_health()) # Can still use other HealthBoard methods
+    except requests.exceptions.RequestException as e:
+        print(f"An error occurred: {e}")

--- a/tests/test_health_board_updater.py
+++ b/tests/test_health_board_updater.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from health_board_api import HealthBoardUpdater
+
+class TestHealthBoardUpdater(unittest.TestCase):
+
+    @patch('health_board_api.HealthBoard.update_item')
+    def test_update_item(self, mock_update_item):
+        # Arrange
+        base_url = "http://fake-url.com"
+        category = "test_category"
+        item = "test_item"
+        status = "testing"
+        message = "This is a test"
+        url = "http://test.com"
+
+        updater = HealthBoardUpdater(base_url, category, item)
+
+        # Act
+        updater.update_item(status=status, message=message, url=url, upsert=False)
+
+        # Assert
+        mock_update_item.assert_called_once_with(category, item, status, message, url, False)


### PR DESCRIPTION
This commit introduces the `HealthBoardUpdater` class, a specialized client for updating a single item on the health board. This class inherits from `HealthBoard` and simplifies the process of updating a specific item by pre-configuring the category and item names.

I have also:
- Added a usage example for the new class.
- Added a test for the new class.
- Updated the README to document the new class.