### PR TITLE
Feat: Make create_category idempotent

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,7 +69,7 @@ def create_category_api():
 
     category_name = data['category_name']
     if category_name in health_data:
-        return jsonify({"error": f"Category '{category_name}' already exists"}), 400
+        return jsonify({"note": f"Category '{category_name}' already exists"}), 200
 
     health_data[category_name] = {}
     return jsonify({category_name: health_data[category_name]}), 201

--- a/health_board_api.py
+++ b/health_board_api.py
@@ -76,12 +76,7 @@ class HealthBoard:
             The JSON response from the API.
         """
         if upsert:
-            try:
-                self.create_category(category_name)
-            except requests.exceptions.HTTPError as e:
-                # Ignore 409 Conflict errors, which indicate the category already exists.
-                if e.response.status_code != 409:
-                    raise
+            self.create_category(category_name)
 
         endpoint = f'categories/{category_name}/items'
         response = self._request('POST', endpoint, json={"item_name": item_name})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -43,8 +43,8 @@ class TestAppAPI(unittest.TestCase):
     def test_create_category_duplicate(self):
         self.client.post('/api/categories', json={'category_name': 'Cat1'})
         response = self.client.post('/api/categories', json={'category_name': 'Cat1'})
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('error', response.json)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('note', response.json)
 
     def test_create_category_missing_name(self):
         response = self.client.post('/api/categories', json={})

--- a/tests/test_health_board_api.py
+++ b/tests/test_health_board_api.py
@@ -96,8 +96,8 @@ class TestHealthBoardAPI(unittest.TestCase):
         item_name = "new-item"
         expected_item_data = {"item_name": item_name}
 
-        # Simulate category creation failing with a 409 Conflict, then item creation succeeding
-        mock_create_category_response = self._mock_response(status_code=409, raise_for_status=requests.exceptions.HTTPError(response=self._mock_response(409)))
+        # Simulate category creation returning a 200 OK, then item creation succeeding
+        mock_create_category_response = self._mock_response(status_code=200, json_data={"note": "Category already exists"})
         mock_create_item_response = self._mock_response(status_code=201, json_data=expected_item_data)
         mock_request.side_effect = [mock_create_category_response, mock_create_item_response]
 


### PR DESCRIPTION
This commit updates the `create_category` endpoint to be idempotent. Instead of returning a 409 Conflict error when a category already exists, it now returns a 200 OK with a note. This makes the API more consistent with the `create_item` endpoint and simplifies client-side error handling.

The `health_board_api.py` client has been updated to reflect this change, and the tests have been updated accordingly.