### PR TITLE
Style: Reduce status icon size to 11px

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -42,8 +42,8 @@ tr:hover {
 }
 
 .status-icon {
-    width: 18px;
-    height: 18px;
+    width: 11px;
+    height: 11px;
     border-radius: 50%;
     display: inline-block;
     margin-right: 10px;


### PR DESCRIPTION
I reduced the width and height of the status icon in `static/style.css` from 18px to 11px for a more compact UI.